### PR TITLE
Fix formatting of code block in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,12 +132,14 @@ It's also lightweight, at 5KB minified, 2KB gzipped.
 - Familiar control flow with branching and loops.  See examples above.
 - No transpiler to [maintain](https://github.com/jsdf/coffee-react/issues/28).
 - No [extraneous enclosing tags](https://babeljs.io/repl/#?experimental=false&evaluate=true&loose=false&spec=false&code=%3Cdiv%3E%3C%2Fdiv%3E%0A%3Cdiv%3E%3C%2Fdiv%3E) required:
+
   ```coffee
   renderHeader: ->
     unless @props.signedIn
       crel 'a', href: '...', 'Sign in'
     crel 'h1', 'Tea Shop'
   ```
+
   Just works.
 - [Nice syntax errors](https://github.com/jsdf/coffee-react/issues/32).
 - Half the lines of code. Those closing tags really add up.


### PR DESCRIPTION
The current version is displayed as inline code that starts with “coffee”, instead of a code block: [`README.md` at `0a054854`, section “How is this better than CJSX?”](https://github.com/hurrymaplelad/teact/blob/0a054854d394c99276781725941a76f19f6c3763/README.md#how-is-this-better-than-cjsx)

Adding blank lines around the code block fixes that.
