### PR TITLE
Rename “teacup” to “teact” in plugins test

### DIFF
--- a/test/plugins.coffee
+++ b/test/plugins.coffee
@@ -1,6 +1,6 @@
 expect = require 'expect.js'
-teacup = require '../src/teact'
+teact = require '../src/teact'
 
 describe 'plugins', ->
   it 'are applied via use', ->
-    expect(teacup.use).to.be.a 'function'
+    expect(teact.use).to.be.a 'function'


### PR DESCRIPTION
You may want to delete this test instead, if you don’t need this functionality that was copied from Teacup. If you do want to support plugins, you should probably document the `use` function in the README.
