### PR TITLE
React as a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "coffee-script": ">=1.8.0",
     "expect.js": "^0.3.1",
     "mocha": "^2.3.3",
-    "react-dom": "^15.4.1"
+    "react-dom": "^15.4.1",
+    "react": "^15.4.1"
   },
   "scripts": {
     "pretest": "npm run compile",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "compile": "coffee --compile --output lib/ src/",
     "benchmark": "coffee test/benchmarks"
   },
-  "dependencies": {
+  "peerDependencies": {
     "react": "^15.4.1"
   }
 }


### PR DESCRIPTION
So I was trying to use Teact in a new project and keep `React` up to date.
Currently at the time of this writing `teact` [on npm](https://www.npmjs.com/package/teact) is `teact@1.1.2` and has a dependency of `react@^0.14.2` and I'm using `react@latest` creating a structure like:
```
├── react@15.4.1
└─┬ teact@1.1.2
  └── react@0.14.8
```
Unfortunately common bundlers today will include both versions of `react` in the bundle, and Teact completely explodes because of it.

Is there any reason why `react` must be a `dependency` rather then a `peerDependency` so you can choose which version of `react` to use in your project even if Teact is behind a few versions on `npm`?